### PR TITLE
Harden frontend nginx runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM node:24-alpine as build
+FROM --platform=$BUILDPLATFORM node:24-alpine AS build
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM --platform=$TARGETPLATFORM nginx:1.29.1-alpine
+FROM nginx:1.31.2-trixie
 
 COPY deploy/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - my-private-ntwk
 
   gateway:
-    image: nginx:1.29.7-perl
+    image: nginx:1.31.2-trixie
     depends_on:
       - frontend
       - backend


### PR DESCRIPTION
## What changed

- moves the production frontend runtime to `nginx:1.31.2-trixie`
- updates the repository-local gateway to the same nginx release
- keeps all unrelated Bonsai/Qwen work out of this release

## Why

The previous nginx images contained fixable critical/high package findings. The replacement scanned clean at the P0 audit point in time.

## Verification

- `npm run lint`
- 438/438 frontend tests
- `npm run build`
- production container smoke test completed during the audit