### PR TITLE
Use Bonsai as the default Ollama model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@ RUN npm ci
 # Copy source code
 COPY . .
 
+# The model remains user-editable in the UI. This controls only the initial
+# value baked into the static frontend bundle.
+ARG VITE_DEFAULT_OLLAMA_MODEL=hf.co/prism-ml/Bonsai-27B-gguf:Q1_0
+ENV VITE_DEFAULT_OLLAMA_MODEL=${VITE_DEFAULT_OLLAMA_MODEL}
+
 # Build the application
 RUN npm run build
 

--- a/e2e/tests/llm.chat.spec.ts
+++ b/e2e/tests/llm.chat.spec.ts
@@ -44,7 +44,7 @@ test.describe('Ollama Chat', () => {
   test('exposes default model and allows editing the value', async () => {
     await chatPage.goto();
     await chatPage.expandSettings();
-    await expect(chatPage.modelInput).toHaveValue('qwen3.5:2b');
+    await expect(chatPage.modelInput).toHaveValue('hf.co/prism-ml/Bonsai-27B-gguf:Q1_0');
 
     await chatPage.modelInput.fill('custom-model');
     await expect(chatPage.modelInput).toHaveValue('custom-model');

--- a/e2e/tests/llm.generate.spec.ts
+++ b/e2e/tests/llm.generate.spec.ts
@@ -20,10 +20,10 @@ test.describe('Ollama Generate', () => {
     await expect(generatePage.responseContent).toContainText('Release plan: mock Ollama service ready');
   });
 
-  test('uses qwen3.5:2b by default and allows editing the value', async () => {
+  test('uses Bonsai by default and allows editing the value', async () => {
     await generatePage.goto();
     await generatePage.expandSettings();
-    await expect(generatePage.modelInput).toHaveValue('qwen3.5:2b');
+    await expect(generatePage.modelInput).toHaveValue('hf.co/prism-ml/Bonsai-27B-gguf:Q1_0');
 
     await generatePage.modelInput.fill('custom-model');
     await expect(generatePage.modelInput).toHaveValue('custom-model');

--- a/e2e/tests/llm.tools.spec.ts
+++ b/e2e/tests/llm.tools.spec.ts
@@ -47,7 +47,7 @@ test.describe('Ollama Tool Calling', () => {
     await toolChatPage.goto();
     await toolChatPage.expandSettings();
     await expect(toolChatPage.toolDefinitionJson).toContainText('get_product_snapshot');
-    await expect(toolChatPage.modelInput).toHaveValue('qwen3.5:2b');
+    await expect(toolChatPage.modelInput).toHaveValue('hf.co/prism-ml/Bonsai-27B-gguf:Q1_0');
     await expect(toolChatPage.thinkingCheckbox).not.toBeChecked();
   });
 

--- a/src/hooks/useOllamaChat.test.ts
+++ b/src/hooks/useOllamaChat.test.ts
@@ -45,7 +45,7 @@ describe('useOllamaChat', () => {
     expect(result.current.messages).toEqual([
       { role: 'system', content: 'You are a helpful AI assistant. You must use the conversation history to answer questions.' }
     ]);
-    expect(result.current.model).toBe('qwen3.5:2b');
+    expect(result.current.model).toBe('hf.co/prism-ml/Bonsai-27B-gguf:Q1_0');
     expect(result.current.temperature).toBe(0.8);
   });
 

--- a/src/hooks/useOllamaGenerate.test.ts
+++ b/src/hooks/useOllamaGenerate.test.ts
@@ -37,7 +37,7 @@ describe('useOllama', () => {
     expect(result.current.isGenerating).toBe(false);
     expect(result.current.response).toBe('');
     expect(result.current.thinking).toBe('');
-    expect(result.current.model).toBe('qwen3.5:2b');
+    expect(result.current.model).toBe('hf.co/prism-ml/Bonsai-27B-gguf:Q1_0');
     expect(result.current.temperature).toBe(0.8);
     expect(result.current.think).toBe(false);
   });
@@ -79,7 +79,7 @@ describe('useOllama', () => {
     expect(result.current.response).toBe('Hello World');
     expect(result.current.isGenerating).toBe(false);
     expect(ollama.generate).toHaveBeenCalledWith({
-      model: 'qwen3.5:2b',
+      model: 'hf.co/prism-ml/Bonsai-27B-gguf:Q1_0',
       prompt: 'test prompt',
       think: false,
       options: { temperature: 0.8 },
@@ -189,7 +189,7 @@ describe('useOllama', () => {
 
     // then
     expect(ollama.generate).toHaveBeenCalledWith({
-      model: 'qwen3.5:2b',
+      model: 'hf.co/prism-ml/Bonsai-27B-gguf:Q1_0',
       prompt: 'test prompt',
       think: false,
       options: { temperature: customTemperature }
@@ -207,7 +207,7 @@ describe('useOllama', () => {
 
     // then
     expect(ollama.generate).toHaveBeenCalledWith({
-      model: 'qwen3.5:2b',
+      model: 'hf.co/prism-ml/Bonsai-27B-gguf:Q1_0',
       prompt: 'test prompt',
       think: false,
       options: { temperature: 0.8 }
@@ -262,7 +262,7 @@ describe('useOllama', () => {
 
     // then
     expect(ollama.generate).toHaveBeenCalledWith({
-      model: 'qwen3.5:2b',
+      model: 'hf.co/prism-ml/Bonsai-27B-gguf:Q1_0',
       prompt: 'test prompt',
       think: true,
       options: { temperature: 0.8 },

--- a/src/hooks/useOllamaToolChat.test.ts
+++ b/src/hooks/useOllamaToolChat.test.ts
@@ -48,7 +48,7 @@ describe('useOllamaToolChat', () => {
     expect(result.current.messages).toEqual([
       { role: 'system', content: expect.stringContaining('tool-calling shopping assistant') }
     ]);
-    expect(result.current.model).toBe('qwen3.5:2b');
+    expect(result.current.model).toBe('hf.co/prism-ml/Bonsai-27B-gguf:Q1_0');
     expect(result.current.temperature).toBe(0.4);
   });
 

--- a/src/lib/ollamaDefaults.ts
+++ b/src/lib/ollamaDefaults.ts
@@ -1,2 +1,7 @@
+export const BONSAI_MODEL = 'hf.co/prism-ml/Bonsai-27B-gguf:Q1_0';
+
 export const DEFAULT_OLLAMA_MODEL =
-  import.meta.env.VITE_DEFAULT_OLLAMA_MODEL?.trim() || 'qwen3.5:2b';
+  import.meta.env.VITE_DEFAULT_OLLAMA_MODEL?.trim() || BONSAI_MODEL;
+
+export const DEFAULT_OLLAMA_MODEL_LABEL =
+  DEFAULT_OLLAMA_MODEL === BONSAI_MODEL ? 'Bonsai 27B · 1-bit' : DEFAULT_OLLAMA_MODEL;

--- a/src/pages/llm/llmPage.test.tsx
+++ b/src/pages/llm/llmPage.test.tsx
@@ -26,6 +26,7 @@ describe('LlmPage (landing)', () => {
     const toolsCard = screen.getByTestId('llm-mode-card-tools');
 
     expect(chatCard).toHaveTextContent('Chat');
+    expect(chatCard).toHaveTextContent('Bonsai 27B · 1-bit');
     expect(chatCard).toHaveAttribute('href', '/llm/chat');
     expect(generateCard).toHaveTextContent('Generate');
     expect(generateCard).toHaveAttribute('href', '/llm/generate');

--- a/src/pages/llm/llmPage.tsx
+++ b/src/pages/llm/llmPage.tsx
@@ -3,14 +3,14 @@ import { ArrowRight, MessageSquare, Sparkles, Workflow } from 'lucide-react';
 import { Surface } from '../../components/ui/surface';
 import { Badge } from '../../components/ui/badge';
 import { cn } from '../../lib/utils';
-import { DEFAULT_OLLAMA_MODEL } from '../../lib/ollamaDefaults';
+import { DEFAULT_OLLAMA_MODEL_LABEL } from '../../lib/ollamaDefaults';
 
 const MODES = [
   {
     id: 'generate',
     title: 'Generate',
     badge: 'Single-shot',
-    highlights: [DEFAULT_OLLAMA_MODEL, 'One-shot prompts', 'Markdown output'],
+    highlights: [DEFAULT_OLLAMA_MODEL_LABEL, 'One-shot prompts', 'Markdown output'],
     icon: Sparkles,
     to: '/llm/generate',
     iconBg: 'bg-slate-900 text-stone-50',
@@ -20,7 +20,7 @@ const MODES = [
     id: 'chat',
     title: 'Chat',
     badge: 'Conversation',
-    highlights: [DEFAULT_OLLAMA_MODEL, 'Custom system prompt', 'Thinking toggle'],
+    highlights: [DEFAULT_OLLAMA_MODEL_LABEL, 'Custom system prompt', 'Thinking toggle'],
     icon: MessageSquare,
     to: '/llm/chat',
     iconBg: 'bg-slate-900 text-stone-50',
@@ -30,7 +30,7 @@ const MODES = [
     id: 'tools',
     title: 'Chat + Tools',
     badge: 'Conversation + Tools',
-    highlights: [DEFAULT_OLLAMA_MODEL, 'Live tool output', 'Grounded responses'],
+    highlights: [DEFAULT_OLLAMA_MODEL_LABEL, 'Live tool output', 'Grounded responses'],
     icon: Workflow,
     to: '/llm/tools',
     iconBg: 'bg-slate-900 text-stone-50',

--- a/src/pages/ollama/generatePage.test.tsx
+++ b/src/pages/ollama/generatePage.test.tsx
@@ -82,7 +82,7 @@ describe('OllamaGeneratePage', () => {
       expect(screen.getByText('Hello World')).toBeInTheDocument();
     });
     expect(vi.mocked(ollama.generate)).toHaveBeenCalledWith(expect.objectContaining({
-      model: 'qwen3.5:2b'
+      model: 'hf.co/prism-ml/Bonsai-27B-gguf:Q1_0'
     }));
   });
 
@@ -217,7 +217,7 @@ describe('OllamaGeneratePage', () => {
     
     // then
     const modelInput = screen.getByTestId('model-input');
-    expect(modelInput).toHaveValue('qwen3.5:2b');
+    expect(modelInput).toHaveValue('hf.co/prism-ml/Bonsai-27B-gguf:Q1_0');
   });
 
   it('renders thinking checkbox unchecked by default', () => {


### PR DESCRIPTION
## Summary
- replace the Qwen frontend default with the 1-bit Bonsai 27B model
- keep the model editable in all LLM modes and support a build-time `VITE_DEFAULT_OLLAMA_MODEL` override
- show a readable Bonsai label on the LLM landing page
- update unit and browser contract coverage for the new default

## Contract compatibility
- the existing Ollama mock remains unchanged and accepts the explicit Bonsai model identifier
- chat, generate, and tool-calling browser flows pass against `slawekradzyminski/ollama-mock:local-qwen35-2b`
- explicit `qwen3.5:2b` requests used by production/course contract fixtures remain supported

## Validation
- `npm run lint`
- `npm test -- --run` (438/438)
- `npm run build`
- `npx playwright test e2e/tests/llm.chat.spec.ts e2e/tests/llm.generate.spec.ts e2e/tests/llm.tools.spec.ts` (13/13)