### PR TITLE
Prepare 3.7.9 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite",
-  "version": "3.7.8",
+  "version": "3.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite",
-      "version": "3.7.8",
+      "version": "3.7.9",
       "dependencies": {
         "@awesome-testing/platform-client": "file:vendor/awesome-testing-platform-client-0.1.3.tgz",
         "@hookform/resolvers": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite",
   "private": true,
-  "version": "3.7.8",
+  "version": "3.7.9",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What changed\n\n- bumps the frontend release version to 3.7.9\n- keeps the merged dependency updates as the exact release source\n\n## Validation\n\n- npm test -- --run\n- npm run build\n\nAfter merge, tag the verified main commit as v3.7.9 to publish the multi-architecture image through GitHub Actions.