### PR TITLE
Remove retired AI Lab navigation

### DIFF
--- a/e2e/tests/a11y.navigation.spec.ts
+++ b/e2e/tests/a11y.navigation.spec.ts
@@ -19,7 +19,6 @@ test.describe('Navigation keyboard accessibility', () => {
       'desktop-menu-send-email',
       'desktop-menu-qr-code',
       'desktop-menu-llm',
-      'desktop-menu-ai-lab',
       'desktop-menu-traffic-monitor',
     ];
     if (await adminLink.count()) {

--- a/e2e/tests/sso.spec.ts
+++ b/e2e/tests/sso.spec.ts
@@ -19,8 +19,8 @@ test.describe('SSO login', () => {
     await expect.poll(async () => page.evaluate(() => localStorage.getItem('refreshToken'))).not.toBeNull();
   });
 
-  test('returns to a deep AI Lab route after authentication', async ({ page }) => {
-    await page.goto('/login?returnTo=%2Flearn%2Fhow-ai-agent-works%2Fcourse%2Fagent-loop');
+  test('returns to an internal route after authentication', async ({ page }) => {
+    await page.goto('/login?returnTo=%2Fproducts');
     await page.getByTestId('login-sso-button').click();
 
     await expect(page).toHaveURL(/\/protocol\/openid-connect\/auth/);
@@ -28,7 +28,7 @@ test.describe('SSO login', () => {
     await page.getByRole('textbox', { name: 'Password' }).fill(SSO_PASSWORD);
     await page.getByRole('button', { name: 'Sign In' }).click();
 
-    await expect(page).toHaveURL('/learn/how-ai-agent-works/course/agent-loop');
+    await expect(page).toHaveURL('/products');
     await expect.poll(async () => page.evaluate(() => localStorage.getItem('token'))).not.toBeNull();
     await expect.poll(async () => page.evaluate(() => localStorage.getItem('refreshToken'))).not.toBeNull();
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite",
-  "version": "3.7.9",
+  "version": "3.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite",
-      "version": "3.7.9",
+      "version": "3.7.10",
       "dependencies": {
         "@awesome-testing/platform-client": "file:vendor/awesome-testing-platform-client-0.1.3.tgz",
         "@hookform/resolvers": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite",
   "private": true,
-  "version": "3.7.9",
+  "version": "3.7.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/layout/Navigation.test.tsx
+++ b/src/components/layout/Navigation.test.tsx
@@ -129,7 +129,7 @@ describe('Navigation', () => {
     expect(window.location.pathname).toBe('/profile');
   });
 
-  it('shows LLM and AI Lab links when authenticated', async () => {
+  it('shows the LLM link without the retired AI Lab link when authenticated', async () => {
     // given
     localStorage.setItem('token', 'fake-token');
     localStorage.setItem('refreshToken', 'fake-refresh');
@@ -154,8 +154,7 @@ describe('Navigation', () => {
     // then
     await waitFor(() => {
       expect(screen.getByText('LLM')).toBeInTheDocument();
-      expect(screen.getByTestId('desktop-menu-ai-lab')).toHaveAttribute('href', '/learn/');
-      expect(screen.getByTestId('desktop-menu-ai-lab')).toHaveAttribute('data-navigation', 'document');
+      expect(screen.queryByText('AI Lab')).not.toBeInTheDocument();
     });
   });
 
@@ -250,8 +249,7 @@ describe('Navigation', () => {
     expect(mobileMenu).toHaveTextContent('Cart');
     expect(mobileMenu).toHaveTextContent('Send Email');
     expect(mobileMenu).toHaveTextContent('LLM');
-    expect(screen.getByTestId('mobile-menu-ai-lab')).toHaveAttribute('href', '/learn/');
-    expect(screen.getByTestId('mobile-menu-ai-lab')).toHaveAttribute('data-navigation', 'document');
+    expect(mobileMenu).not.toHaveTextContent('AI Lab');
     expect(mobileMenu).toHaveTextContent('Test User');
 
     // when

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -13,7 +13,6 @@ const PRODUCT_NAME = 'Awesome Testing';
 type MenuItem = {
   label: string;
   path: string;
-  documentNavigation?: boolean;
 };
 
 export function Navigation() {
@@ -86,7 +85,6 @@ export function Navigation() {
     { label: 'Send Email', path: '/email' },
     { label: 'QR Code', path: '/qr' },
     { label: 'LLM', path: '/llm' },
-    { label: 'AI Lab', path: '/learn/', documentNavigation: true },
     { label: 'Traffic Monitor', path: '/traffic' },
   ];
 
@@ -122,9 +120,7 @@ export function Navigation() {
                       : 'text-slate-600 hover:bg-white hover:text-slate-900'
                   }`;
                 const testId = `desktop-menu-${item.label.toLowerCase().replace(' ', '-')}`;
-                return item.documentNavigation
-                  ? <a key={item.path} href={item.path} className={className} data-testid={testId} data-navigation="document">{item.label}</a>
-                  : <Link key={item.path} to={item.path} className={className} data-testid={testId}>{item.label}</Link>;
+                return <Link key={item.path} to={item.path} className={className} data-testid={testId}>{item.label}</Link>;
               })}
 
               {isAdmin && adminMenuItems.map((item) => (
@@ -226,9 +222,7 @@ export function Navigation() {
                     : 'bg-white/80 text-slate-700 hover:bg-white hover:text-slate-900'
                 }`;
               const testId = `mobile-menu-${item.label.toLowerCase().replace(' ', '-')}`;
-              return item.documentNavigation
-                ? <a key={item.path} href={item.path} className={className} onClick={() => setIsOpen(false)} data-testid={testId} data-navigation="document">{item.label}</a>
-                : <Link key={item.path} to={item.path} className={className} onClick={() => setIsOpen(false)} data-testid={testId}>{item.label}</Link>;
+              return <Link key={item.path} to={item.path} className={className} onClick={() => setIsOpen(false)} data-testid={testId}>{item.label}</Link>;
             })}
 
             {isAdmin && adminMenuItems.map((item) => (

--- a/src/lib/loginNavigation.ts
+++ b/src/lib/loginNavigation.ts
@@ -3,12 +3,6 @@ export type LoginNavigate = (url: string) => void;
 export function navigateAfterLogin(
   returnTo: string,
   navigate: LoginNavigate,
-  documentNavigate: (url: string) => void = (url) => window.location.assign(url),
 ) {
-  if (returnTo === '/learn' || returnTo.startsWith('/learn/')) {
-    documentNavigate(returnTo);
-    return;
-  }
-
   navigate(returnTo);
 }

--- a/src/lib/sso.test.ts
+++ b/src/lib/sso.test.ts
@@ -56,9 +56,9 @@ describe('sso helper', () => {
   });
 
   it('stores, sanitizes, and consumes the post-SSO return target once', () => {
-    sso.rememberLoginReturnTo('/learn/agent-loop?mode=guided#exercise');
+    sso.rememberLoginReturnTo('/products?view=featured#catalog');
 
-    expect(sso.consumeLoginReturnTo()).toBe('/learn/agent-loop?mode=guided#exercise');
+    expect(sso.consumeLoginReturnTo()).toBe('/products?view=featured#catalog');
     expect(sso.consumeLoginReturnTo()).toBe('/');
 
     sso.rememberLoginReturnTo('https://attacker.example/steal');

--- a/src/pages/auth/loginPage.test.tsx
+++ b/src/pages/auth/loginPage.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { LoginPage } from './loginPage';
-import { navigateAfterLogin } from '../../lib/loginNavigation';
 import { readLoginReturnTo } from '@awesome-testing/platform-client';
 import { Role } from '../../types/auth';
 import { AxiosResponse } from 'axios';
@@ -174,15 +173,6 @@ describe('LoginPage', () => {
     });
   });
 
-  it('uses a document navigation when login returns to the standalone AI Lab', () => {
-    const documentNavigate = vi.fn();
-
-    navigateAfterLogin('/learn/next-token', mockNavigate, documentNavigate);
-
-    expect(documentNavigate).toHaveBeenCalledWith('/learn/next-token');
-    expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
   it.each([
     'https://attacker.example/steal',
     '//attacker.example/steal',
@@ -301,13 +291,13 @@ describe('LoginPage', () => {
 
   it('starts SSO login when the SSO button is clicked', async () => {
     mockSso.enabled = true;
-    mockLocation.search = '?returnTo=%2Flearn%2Fagent-loop%3Fmode%3Dguided';
+    mockLocation.search = '?returnTo=%2Fproducts%3Fview%3Dfeatured';
 
     render(<LoginPage />);
 
     await user.click(screen.getByTestId('login-sso-button'));
 
-    expect(mockSso.rememberLoginReturnTo).toHaveBeenCalledWith('/learn/agent-loop?mode=guided');
+    expect(mockSso.rememberLoginReturnTo).toHaveBeenCalledWith('/products?view=featured');
     expect(mockSso.beginLogin).toHaveBeenCalled();
   });
 

--- a/src/pages/auth/ssoCallbackPage.test.tsx
+++ b/src/pages/auth/ssoCallbackPage.test.tsx
@@ -60,8 +60,8 @@ describe('SsoCallbackPage', () => {
     });
   });
 
-  it('consumes and forwards a deep AI Lab return after SSO', async () => {
-    mockConsumeLoginReturnTo.mockReturnValue('/learn/agent-loop');
+  it('consumes and forwards an internal return target after SSO', async () => {
+    mockConsumeLoginReturnTo.mockReturnValue('/products?view=featured');
     mockCompleteCallback.mockResolvedValue({
       token: 'test-token',
       refreshToken: 'test-refresh',
@@ -72,7 +72,7 @@ describe('SsoCallbackPage', () => {
 
     await waitFor(() => {
       expect(mockConsumeLoginReturnTo).toHaveBeenCalledOnce();
-      expect(mockNavigateAfterLogin).toHaveBeenCalledWith('/learn/agent-loop', expect.any(Function));
+      expect(mockNavigateAfterLogin).toHaveBeenCalledWith('/products?view=featured', expect.any(Function));
     });
   });
 


### PR DESCRIPTION
## What changed

- removes the authenticated desktop and mobile `AI Lab` navigation item
- removes obsolete document-navigation handling for LocalStack `/learn/*` returns
- keeps generic safe internal post-login and SSO return handling
- bumps the frontend patch version to `3.7.10`

## Why

AI Learning Lab is moving to the Awesome Testing product and the standalone LocalStack route is being retired. The legacy commerce frontend must stop linking to that route before the gateway removal is deployed.

## Validation

- `npm run lint`
- `npm test` — 443 tests passed
- `npm run build`