### PR TITLE
Refresh frontend development and CI images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         shard: [1, 2, 3]
     services:
       docker:
-        image: docker:stable
+        image: docker:29.6.2-cli@sha256:be132a9f282288de4afaf63379dff75711fda0147c6b72a9df44e51841402144
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock          
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   backend:
-    image: ${BACKEND_IMAGE:-slawekradzyminski/backend:3.7.13@sha256:c7c7d3298bd2b140bc1f914c147d1932b6d493d2a16a793a350f3ad9bde6fa69}
+    image: ${BACKEND_IMAGE:-slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7}
     expose:
       - "4001"
     hostname: backend
@@ -58,7 +58,7 @@ services:
     networks:
       - my-private-ntwk
   ollama-mock:
-    image: slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872
+    image: slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e
     restart: always
     ports:
       - "11434:11434"


### PR DESCRIPTION
## Summary
- update backend and Ollama-mock development defaults to the reviewed release set
- replace deprecated `docker:stable` CI service with an immutable Docker 29.6.2 CLI image

## Verification
- 443 unit tests
- production build
- `docker compose config --quiet`