### PR TITLE
Sync release images and strengthen semantic contracts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   backend:
-    image: ${BACKEND_IMAGE:-slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7}
+    image: ${BACKEND_IMAGE:-slawekradzyminski/backend:3.7.15@sha256:3a4255b3d51d7cbc4e8690f9f9608487114dd24fa526c1bd897895dbe1143bf0}
     expose:
       - "4001"
     hostname: backend
@@ -58,7 +58,7 @@ services:
     networks:
       - my-private-ntwk
   ollama-mock:
-    image: slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e
+    image: slawekradzyminski/ollama-mock:1.0.9@sha256:24852d0f78eb7ed208bb1eaaab1d912d29e5e74d6c28c2e6a31dd1cbcdedbdab
     restart: always
     ports:
       - "11434:11434"

--- a/src/lib/runtimeConfig.test.ts
+++ b/src/lib/runtimeConfig.test.ts
@@ -102,6 +102,21 @@ describe('runtimeConfig', () => {
     ).toBeNull();
   });
 
+  it('does not implicitly enable training SSO on unrelated loopback ports', () => {
+    expect(
+      getSsoConfig(
+        {},
+        { origin: 'http://localhost:5173' } as Location,
+      ),
+    ).toBeNull();
+    expect(
+      getSsoConfig(
+        {},
+        { origin: 'http://127.0.0.1:4001' } as Location,
+      ),
+    ).toBeNull();
+  });
+
   it('trims configured API values and repeated trailing slashes', () => {
     expect(
       getApiBaseUrl(


### PR DESCRIPTION
## What changed
- update development Compose pins to backend 3.7.15 and Ollama mock 1.0.9
- prove implicit training SSO is restricted to the designated loopback gateway port

## Why
Keep local Compose aligned with the compatibility set and kill the frozen semantic mutant that enabled SSO on unrelated loopback applications.

## Validation
- focused runtime-config tests passed
- frontend semantic mutant killed
- `docker compose config --quiet`